### PR TITLE
Replace black/flake8/isort with ruff for lint + format

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -43,9 +43,13 @@ jobs:
         pip install .
         pip install -r tests/requirements.txt
 
-    - name: Lint with flake8
+    - name: Lint with ruff
       run: |
-        flake8 mobile_env --per-file-ignores="__init__.py:F401"
+        ruff check .
+
+    - name: Check formatting with ruff
+      run: |
+        ruff format --check .
 
     - name: Run tests with pytest
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,13 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v6.0.0
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
--   repo: https://github.com/psf/black
-    rev: 22.10.0
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.16.2
     hooks:
-    -   id: black
--   repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
-    hooks:
-    -   id: flake8
--   repo: https://github.com/pycqa/isort
-    rev: 5.12.0
-    hooks:
-    -   id: isort
+    -   id: ruff-check
+        args: [--fix]
+    -   id: ruff-format

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,8 +18,9 @@ pytest                                                       # full suite
 pytest tests/test_env_stepping.py -k "small and central"     # single parametrized case
 pytest tests/test_central_envs.py::TestCentralEnvs::test_central_small
 pytest --nbmake examples/test.ipynb                          # notebooks are part of CI
-flake8 mobile_env --per-file-ignores="__init__.py:F401"      # exact CI invocation
-pre-commit run --all-files                                   # black, isort, flake8, yaml
+ruff check .                                                  # lint, exact CI invocation
+ruff format --check .                                         # format check, exact CI invocation
+pre-commit run --all-files                                   # ruff (lint + format), yaml checks
 ```
 
 Docs (Sphinx, published to ReadTheDocs via `.readthedocs.yaml`):
@@ -34,9 +35,10 @@ cd docs && make html          # output in docs/_build/html
 stubs, not generated at build time — a new module needs a matching rst entry (note that
 `mobile_env.wrappers` is currently missing from `docs/source/mobile_env.rst`).
 
-flake8 config is in `setup.cfg` (max-line-length 100, ignores E203); there is no `pyproject.toml`.
-Black/isort run only via pre-commit — CI does not check formatting.
-Python >= 3.9; CI matrix is 3.9–3.12 on ubuntu/macos/windows.
+ruff (lint + format) config is in `ruff.toml` (line-length 100, select `E`, `F`, `W`, `I`); there is
+no `pyproject.toml`. Both `ruff check` and `ruff format --check` run in CI and via pre-commit.
+Python >= 3.10; CI matrix is 3.10–3.13 on ubuntu/macos/windows (see `.github/workflows/python-package.yml`
+for the windows+3.13 exclusion).
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![CI](https://github.com/stefanbschneider/mobile-env/actions/workflows/python-package.yml/badge.svg)](https://github.com/stefanbschneider/mobile-env/actions/workflows/python-package.yml)
 [![PyPI](https://github.com/stefanbschneider/mobile-env/actions/workflows/python-publish.yml/badge.svg)](https://github.com/stefanbschneider/mobile-env/actions/workflows/python-publish.yml)
 [![Documentation](https://readthedocs.org/projects/mobile-env/badge/?version=latest)](https://mobile-env.readthedocs.io/en/latest/?badge=latest)
-[![Code Style: Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stefanbschneider/mobile-env/blob/master/examples/demo.ipynb)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stefanbschneider/mobile-env/blob/main/examples/demo.ipynb)
 
 
 # mobile-env: An Open Environment for Autonomous Coordination in Mobile Networks
@@ -29,8 +29,8 @@ To maximize QoE globally, the policy must recognize that (1) the data rate of an
 
 **Try mobile-env:**
 
-- Part I: Customizing mobile-env and single-agent RL with stable-baselines3: [![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stefanbschneider/mobile-env/blob/master/examples/demo.ipynb)
-- Part II: Multi-agent RL on mobile-env with Ray RLlib: [![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stefanbschneider/mobile-env/blob/master/examples/rllib.ipynb)
+- Part I: Customizing mobile-env and single-agent RL with stable-baselines3: [![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stefanbschneider/mobile-env/blob/main/examples/demo.ipynb)
+- Part II: Multi-agent RL on mobile-env with Ray RLlib: [![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stefanbschneider/mobile-env/blob/main/examples/rllib.ipynb)
 
 Documentation and API: [ReadTheDocs](https://mobile-env.readthedocs.io/en/latest/)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![CI](https://github.com/stefanbschneider/mobile-env/actions/workflows/python-package.yml/badge.svg)](https://github.com/stefanbschneider/mobile-env/actions/workflows/python-package.yml)
-[![PyPI](https://github.com/stefanbschneider/mobile-env/actions/workflows/python-publish.yml/badge.svg)](https://github.com/stefanbschneider/mobile-env/actions/workflows/python-publish.yml)
+[![PyPI](https://img.shields.io/pypi/v/mobile-env)](https://pypi.org/project/mobile-env/)
 [![Documentation](https://readthedocs.org/projects/mobile-env/badge/?version=latest)](https://mobile-env.readthedocs.io/en/latest/?badge=latest)
+[![License: MIT](https://img.shields.io/github/license/stefanbschneider/mobile-env)](https://github.com/stefanbschneider/mobile-env/blob/main/LICENSE)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/stefanbschneider/mobile-env/blob/main/examples/demo.ipynb)
 

--- a/docs/scripts/utility.py
+++ b/docs/scripts/utility.py
@@ -24,9 +24,9 @@ def log_utility(curr_dr):
     # better: 10*log10(x) --> clip to [-20, 20];
     # -20 for <= 0.01 dr; +20 for >= 100 dr
     # ensure min/max utility are set correctly for this utility function
-    assert (
-        MIN_UTILITY == -20 and MAX_UTILITY == 20
-    ), "The chosen log utility requires min/max utility to be -20/+20"
+    assert MIN_UTILITY == -20 and MAX_UTILITY == 20, (
+        "The chosen log utility requires min/max utility to be -20/+20"
+    )
     if curr_dr == 0:
         return MIN_UTILITY
     return np.clip(10 * np.log10(curr_dr), MIN_UTILITY, MAX_UTILITY)

--- a/mobile_env/core/base.py
+++ b/mobile_env/core/base.py
@@ -203,9 +203,7 @@ class MComCore(gymnasium.Env):
 
         # extra options currently not supported
         if options is not None and options != {}:
-            raise NotImplementedError(
-                "Passing extra options on env.reset() is not supported."
-            )
+            raise NotImplementedError("Passing extra options on env.reset() is not supported.")
 
         # reset state kept by arrival pattern, channel, scheduler, etc.
         self.arrival.reset()
@@ -309,14 +307,10 @@ class MComCore(gymnasium.Env):
         self.macro = self.macro_datarates(self.datarates)
 
         # compute utilities from UEs' data rates & log its mean value
-        self.utilities = {
-            ue: self.utility.utility(self.macro[ue]) for ue in self.active
-        }
+        self.utilities = {ue: self.utility.utility(self.macro[ue]) for ue in self.active}
 
         # scale utilities to range [-1, 1] before computing rewards
-        self.utilities = {
-            ue: self.utility.scale(util) for ue, util in self.utilities.items()
-        }
+        self.utilities = {ue: self.utility.scale(util) for ue, util in self.utilities.items()}
 
         # compute rewards from utility for each UE
         # method is defined by handler according to strategy pattern
@@ -336,11 +330,7 @@ class MComCore(gymnasium.Env):
 
         # update list of active UEs & add those that begin to request service
         self.active = sorted(
-            [
-                ue
-                for ue in self.users.values()
-                if ue.extime > self.time and ue.stime <= self.time
-            ],
+            [ue for ue in self.users.values() if ue.extime > self.time and ue.stime <= self.time],
             key=lambda ue: ue.ue_id,
         )
 
@@ -396,9 +386,7 @@ class MComCore(gymnasium.Env):
         snrs = [self.channel.snr(bs, ue) for ue in conns]
 
         # UE's max. data rate achievable when BS schedules all resources to it
-        max_allocation = [
-            self.channel.datarate(bs, ue, snr) for snr, ue in zip(snrs, conns)
-        ]
+        max_allocation = [self.channel.datarate(bs, ue, snr) for snr, ue in zip(snrs, conns)]
 
         # BS shares resources among connected user equipments
         rates = self.scheduler.share(bs, max_allocation)
@@ -412,8 +400,7 @@ class MComCore(gymnasium.Env):
         idle = self.utility.scale(self.utility.lower)
 
         util = {
-            bs: sum(self.utilities[ue] for ue in self.connections[bs])
-            / len(self.connections[bs])
+            bs: sum(self.utilities[ue] for ue in self.connections[bs]) / len(self.connections[bs])
             if self.connections[bs]
             else idle
             for bs in self.stations.values()
@@ -427,17 +414,13 @@ class MComCore(gymnasium.Env):
         config = self.default_config()["ue"]
 
         for bs in self.stations.values():
-            isolines[bs] = self.channel.isoline(
-                bs, config, (self.width, self.height), drate
-            )
+            isolines[bs] = self.channel.isoline(bs, config, (self.width, self.height), drate)
 
         return isolines
 
     def features(self) -> Dict[int, Dict[str, np.ndarray]]:
         # fix ordering of BSs for observations
-        stations = sorted(
-            [bs for bs in self.stations.values()], key=lambda bs: bs.bs_id
-        )
+        stations = sorted([bs for bs in self.stations.values()], key=lambda bs: bs.bs_id)
 
         # compute average utility of each basestation's connections
         bs_utilities = self.station_utilities()
@@ -470,9 +453,7 @@ class MComCore(gymnasium.Env):
                 bs: util if self.check_connectivity(bs, ue) else idle
                 for bs, util in bs_utilities.items()
             }
-            util_bcast = np.asarray(
-                [util_bcast[bs] for bs in stations], dtype=np.float32
-            )
+            util_bcast = np.asarray([util_bcast[bs] for bs in stations], dtype=np.float32)
 
             # (5) receive broadcast of (normalized) connected UE count
             # if broadcast is not received, set UE connection count to zero
@@ -501,9 +482,7 @@ class MComCore(gymnasium.Env):
             """Define dummy observation for non-active UEs."""
             onehot = np.zeros(self.NUM_STATIONS, dtype=np.float32)
             snrs = np.zeros(self.NUM_STATIONS, dtype=np.float32)
-            utility = np.asarray(
-                [self.utility.scale(self.utility.lower)], dtype=np.float32
-            )
+            utility = np.asarray([self.utility.scale(self.utility.lower)], dtype=np.float32)
             idle = self.utility.scale(self.utility.lower)
             util_bcast = idle * np.ones(self.NUM_STATIONS, dtype=np.float32)
             num_connected = np.ones(self.NUM_STATIONS, dtype=np.float32)

--- a/mobile_env/core/channels.py
+++ b/mobile_env/core/channels.py
@@ -85,9 +85,7 @@ class Channel:
         # collision with right boundary of map rectangle
         rgt_x1, rgt_y1 = width, np.tan(theta) * (width - x0) + y0
         # collision with upper boundary of map rectangle
-        upr_x1, upr_y1 = (-1) * np.tan(theta - 1 / 2 * np.pi) * (
-            height - y0
-        ) + x0, height
+        upr_x1, upr_y1 = (-1) * np.tan(theta - 1 / 2 * np.pi) * (height - y0) + x0, height
         # collision with left boundary of map rectangle
         lft_x1, lft_y1 = 0.0, np.tan(theta) * (0.0 - x0) + y0
         # collision with lower boundary of map rectangle
@@ -128,14 +126,8 @@ class OkumuraHata(Channel):
     def power_loss(self, bs: BaseStation, ue: UserEquipment):
         distance = bs.point.distance(ue.point)
 
-        ch = (
-            0.8
-            + (1.1 * np.log10(bs.frequency) - 0.7) * ue.height
-            - 1.56 * np.log10(bs.frequency)
-        )
-        tmp_1 = (
-            69.55 - ch + 26.16 * np.log10(bs.frequency) - 13.82 * np.log10(bs.height)
-        )
+        ch = 0.8 + (1.1 * np.log10(bs.frequency) - 0.7) * ue.height - 1.56 * np.log10(bs.frequency)
+        tmp_1 = 69.55 - ch + 26.16 * np.log10(bs.frequency) - 13.82 * np.log10(bs.height)
         tmp_2 = 44.9 - 6.55 * np.log10(bs.height)
 
         # add small epsilon to avoid log(0) if distance = 0

--- a/mobile_env/core/logging.py
+++ b/mobile_env/core/logging.py
@@ -4,9 +4,7 @@ import pandas as pd
 
 
 class Monitor:
-    def __init__(
-        self, scalar_metrics: Dict, ue_metrics: Dict, bs_metrics: Dict, **kwargs
-    ):
+    def __init__(self, scalar_metrics: Dict, ue_metrics: Dict, bs_metrics: Dict, **kwargs):
 
         self.scalar_metrics: Dict = scalar_metrics
         self.ue_metrics: Dict = ue_metrics
@@ -27,20 +25,13 @@ class Monitor:
         """Evaluate and update metrics given the simulation state."""
 
         # evaluate scalar, ue, bs metrics by passing the simulation state
-        scalar_updates = {
-            name: metric(simulation) for name, metric in self.scalar_metrics.items()
-        }
-        ue_updates = {
-            name: metric(simulation) for name, metric in self.ue_metrics.items()
-        }
-        bs_updates = {
-            name: metric(simulation) for name, metric in self.bs_metrics.items()
-        }
+        scalar_updates = {name: metric(simulation) for name, metric in self.scalar_metrics.items()}
+        ue_updates = {name: metric(simulation) for name, metric in self.ue_metrics.items()}
+        bs_updates = {name: metric(simulation) for name, metric in self.bs_metrics.items()}
 
         # update results by appending the metrics' return values
         self.scalar_results = {
-            name: self.scalar_results[name] + [scalar_updates[name]]
-            for name in self.scalar_metrics
+            name: self.scalar_results[name] + [scalar_updates[name]] for name in self.scalar_metrics
         }
         self.ue_results = {
             name: self.ue_results[name] + [ue_updates[name]] for name in self.ue_metrics

--- a/mobile_env/core/movement.py
+++ b/mobile_env/core/movement.py
@@ -7,9 +7,7 @@ from mobile_env.core.entities import UserEquipment
 
 
 class Movement:
-    def __init__(
-        self, width: float, height: float, seed: int, reset_rng_episode: str, **kwargs
-    ):
+    def __init__(self, width: float, height: float, seed: int, reset_rng_episode: str, **kwargs):
 
         self.width, self.height = width, height
         self.reset_rng_episode = reset_rng_episode

--- a/mobile_env/core/utilities.py
+++ b/mobile_env/core/utilities.py
@@ -26,11 +26,7 @@ class Utility:
 
 class BoundedLogUtility(Utility):
     def __init__(
-        self,
-        lower: float,
-        upper: float,
-        coeffs: Tuple[float, float, float],
-        **kwargs: Dict
+        self, lower: float, upper: float, coeffs: Tuple[float, float, float], **kwargs: Dict
     ):
         super().__init__(**kwargs)
         self.lower = lower
@@ -42,9 +38,7 @@ class BoundedLogUtility(Utility):
         if datarate <= 0.0:
             return self.lower
 
-        utility = np.clip(
-            w1 * np.log(w2 + datarate) / np.log(w3), self.lower, self.upper
-        )
+        utility = np.clip(w1 * np.log(w2 + datarate) / np.log(w3), self.lower, self.upper)
         return utility
 
     def scale(self, utility) -> float:

--- a/mobile_env/handlers/central.py
+++ b/mobile_env/handlers/central.py
@@ -28,9 +28,7 @@ class MComCentralHandler(Handler):
     @classmethod
     def action(cls, env, actions: Tuple[int]) -> Dict[int, int]:
         """Transform flattend actions to expected shape of core environment."""
-        assert len(actions) == len(
-            env.users
-        ), "Number of actions must equal overall UEs."
+        assert len(actions) == len(env.users), "Number of actions must equal overall UEs."
 
         users = sorted(env.users)
         return {ue_id: action for ue_id, action in zip(users, actions)}
@@ -60,7 +58,6 @@ class MComCentralHandler(Handler):
 
     @classmethod
     def check(cls, env):
-        assert [
-            ue.stime <= 0.0 and ue.extime >= env.EP_MAX_TIME
-            for ue in env.users.values()
-        ], "Central environment cannot handle a changing number of UEs."
+        assert [ue.stime <= 0.0 and ue.extime >= env.EP_MAX_TIME for ue in env.users.values()], (
+            "Central environment cannot handle a changing number of UEs."
+        )

--- a/mobile_env/handlers/multi_agent.py
+++ b/mobile_env/handlers/multi_agent.py
@@ -23,10 +23,7 @@ class MComMAHandler(Handler):
     @classmethod
     def action_space(cls, env: MComCore) -> gymnasium.spaces.Dict:
         return gymnasium.spaces.Dict(
-            {
-                ue.ue_id: gymnasium.spaces.Discrete(env.NUM_STATIONS + 1)
-                for ue in env.users.values()
-            }
+            {ue.ue_id: gymnasium.spaces.Discrete(env.NUM_STATIONS + 1) for ue in env.users.values()}
         )
 
     @classmethod
@@ -75,14 +72,11 @@ class MComMAHandler(Handler):
 
         # select observations for multi-agent setting from base feature set
         obs = {
-            ue_id: [obs_dict[key] for key in cls.features]
-            for ue_id, obs_dict in features.items()
+            ue_id: [obs_dict[key] for key in cls.features] for ue_id, obs_dict in features.items()
         }
 
         # flatten each UE's Dict observation to vector representation
-        obs = {
-            ue_id: np.concatenate([o for o in ue_obs]) for ue_id, ue_obs in obs.items()
-        }
+        obs = {ue_id: np.concatenate([o for o in ue_obs]) for ue_id, ue_obs in obs.items()}
         return obs
 
     @classmethod

--- a/mobile_env/scenarios/large.py
+++ b/mobile_env/scenarios/large.py
@@ -25,10 +25,7 @@ class MComLarge(MComCore):
             (265, 50),
         ]
         stations = [(x, y) for x, y in stations]
-        stations = [
-            BaseStation(bs_id, pos, **config["bs"])
-            for bs_id, pos in enumerate(stations)
-        ]
+        stations = [BaseStation(bs_id, pos, **config["bs"]) for bs_id, pos in enumerate(stations)]
 
         num_ues = 30
         ues = [UserEquipment(ue_id, **config["ue"]) for ue_id in range(num_ues)]

--- a/mobile_env/scenarios/medium.py
+++ b/mobile_env/scenarios/medium.py
@@ -19,10 +19,7 @@ class MComMedium(MComCore):
             (160, 110),
         ]
         stations = [(x, y) for x, y in stations]
-        stations = [
-            BaseStation(bs_id, pos, **config["bs"])
-            for bs_id, pos in enumerate(stations)
-        ]
+        stations = [BaseStation(bs_id, pos, **config["bs"]) for bs_id, pos in enumerate(stations)]
 
         num_ues = 15
         ues = [UserEquipment(ue_id, **config["ue"]) for ue_id in range(num_ues)]

--- a/mobile_env/scenarios/small.py
+++ b/mobile_env/scenarios/small.py
@@ -10,8 +10,7 @@ class MComSmall(MComCore):
 
         station_pos = [(110, 130), (65, 80), (120, 30)]
         stations = [
-            BaseStation(bs_id, pos, **config["bs"])
-            for bs_id, pos in enumerate(station_pos)
+            BaseStation(bs_id, pos, **config["bs"]) for bs_id, pos in enumerate(station_pos)
         ]
         num_ues = 5
         ues = [UserEquipment(ue_id, **config["ue"]) for ue_id in range(num_ues)]

--- a/mobile_env/wrappers/multi_agent.py
+++ b/mobile_env/wrappers/multi_agent.py
@@ -51,14 +51,13 @@ class RLlibMAWrapper(MultiAgentEnv):
         assert self.prev_step_ues is not None
         inactive_ues = self.prev_step_ues - set([ue.ue_id for ue in self.env.active])
         truncateds: MultiAgentDict = {
-            ue_id: True if ue_id in inactive_ues else False
-            for ue_id in self.prev_step_ues
+            ue_id: True if ue_id in inactive_ues else False for ue_id in self.prev_step_ues
         }
         truncateds["__all__"] = truncated
         # Terminated is always False since there is no particular terminal end state.
-        assert (
-            not terminated
-        ), "There is no natural episode termination. terminated should be False."
+        assert not terminated, (
+            "There is no natural episode termination. terminated should be False."
+        )
         terminateds: MultiAgentDict = {ue_id: False for ue_id in self.prev_step_ues}
         terminateds["__all__"] = False
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,19 @@
+# Ruff replaces black (formatting), isort (import sorting), and flake8 (linting).
+# https://docs.astral.sh/ruff/
+
+line-length = 100
+
+# ruff format defaults to reformatting notebooks and the Python code fences inside markdown docs
+# too; black (previously used via pre-commit) never touched either, so keep excluding them to
+# avoid a large diff unrelated to this repo's actual .py sources and to not risk breaking
+# `pytest --nbmake examples/test.ipynb`.
+extend-exclude = ["*.ipynb", "*.md"]
+
+[lint]
+# Match the previous flake8 setup (default E/F/W) plus isort's import-sorting (I).
+select = ["E", "F", "W", "I"]
+
+[lint.per-file-ignores]
+# unused imports are intentional in __init__.py (re-exported for `import mobile_env` side
+# effects / package API), matching the old `--per-file-ignores="__init__.py:F401"` CI flag.
+"__init__.py" = ["F401"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,0 @@
-[flake8]
-max-line-length = 100
-extend-ignore = E203

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,7 @@
 # extra requirements for testing
 pre-commit
 importlib-metadata
-flake8
+ruff
 pytest
 nbmake
 tensorboard


### PR DESCRIPTION
## Summary

- Replace black, flake8, and isort with [ruff](https://github.com/astral-sh/ruff) for both linting and formatting.
- `ruff.toml`: `line-length = 100` (matches the previous flake8 setting), `select = ["E", "F", "W", "I"]` (`I` replaces isort), and a per-file `F401` ignore for `__init__.py` (previously only passed on the CI flake8 command line via `--per-file-ignores`, so pre-commit never actually enforced it). `*.ipynb` and `*.md` are excluded from `ruff format` — black never touched notebooks, and ruff's markdown support would otherwise reformat the Python code fences embedded in the docs, which is out of scope here.
- Delete `setup.cfg` (it only held the flake8 config).
- `.pre-commit-config.yaml`: drop the black/flake8/isort hooks, add `astral-sh/ruff-pre-commit` (`ruff-check --fix`, `ruff-format`); also bumped the stale `pre-commit-hooks` pin (`v2.3.0` → `v6.0.0`) while touching this file.
- CI (`.github/workflows/python-package.yml`): replace the "Lint with flake8" step with `ruff check .`, and **add** a new `ruff format --check .` step. This is a real behavior change, not just a swap — CI previously never checked formatting at all; black/isort only ran locally via pre-commit.
- `tests/requirements.txt`: `flake8` → `ruff`.
- Reformatted all Python sources with `ruff format` (mostly re-wrapping lines that black had wrapped at 88 chars, now allowed up to 100 to match the lint config) and ran `ruff check --fix` (clean — no violations beyond formatting).

## README badges

- Swapped the "Code Style: Black" badge for the official Ruff badge.
- Removed the "PyPI" badge — it was actually the `python-publish.yml` workflow-status badge, which only runs on release tags, so it reads stale/broken most of the time. Replaced with a real PyPI version badge linking to the package's PyPI page.
- Added a License (MIT) badge, since none existed despite the project being MIT-licensed.
- Pointed the Colab links at `main` instead of `master` — the repo has no `master` branch, so those only ever worked via GitHub's redirect.

## Dependency updates

Beyond the ruff swap itself: `pre-commit-hooks` `v2.3.0` → `v6.0.0`. I checked `uv pip list --outdated`; core runtime deps (gymnasium, numpy, pandas, matplotlib, pygame, shapely) were already bumped and verified in the immediately preceding commit (b07257b), and nothing there is newly outdated except transitive CUDA/nvidia/pydantic-core pins and `gymnasium` 1.2.2 (pinned exactly by `ray[rllib]`, already inside setup.py's `>=0.29.1,<2.0` range) — so those were left alone.

## Not included: the stuck-CI ruleset issue

Separately reported (and diagnosed, but not fixed here — it's a repo Settings change, not a code change): the `main` branch ruleset requires status check `build (ubuntu-latest, 3.9)`, but the CI matrix hasn't run 3.9 since an earlier commit (now 3.10–3.13). That context can never be reported, so every PR — including this one — sits "Expected — Waiting for status to be reported" forever. Fix is to update the ruleset's required checks to swap `3.9` for `3.13` (`Settings → Rules → Rulesets → main`).

## Verification

- `pytest` — 11 passed
- `pytest --nbmake examples/test.ipynb` — 1 passed
- `pre-commit run --all-files` — clean
- `ruff check .` / `ruff format --check .` — clean
- Sanity-checked the ruff config actually enforces line length and import order (not just defaults) by injecting a >100-char line and unsorted imports into scratch copies and confirming `ruff check` flags them (E501, I001) before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)