### PR TITLE
docs: add papers confirmed to use mobile-env to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,14 @@ env = gymnasium.make('mobile-small-central-v0', config=config)
 
 If you are using `movile-env`, please let us know and we are happy to link to your project from the readme. You can also open a pull request yourself.
 
+* [Mir Riyanul Islam, Shaibal Barua, Mobyen Uddin Ahmed, Shahina Begum, "Explaining Agents' Interactions Through their Causal Behavior and Counterfactuals", 2026](https://doi.org/10.1007/978-3-032-31141-2_20)
+* [Zeyu Fang, Shu Hong, Huu Trung Thieu, Nakjung Choi, Tian Lan, "ZODIAC: Zero-shot Offline Diffusion for Inferring Multi-xApps Conflicts in Open Radio Access Networks", 2026](https://arxiv.org/abs/2604.19610)
+* [Nicolas Helson, Pegah Alizadeh, Anastasios Giovanidis, "Selecting Offline Reinforcement Learning Algorithms for Stochastic Network Control", 2026](https://arxiv.org/abs/2603.03932)
+* [Weijun Huang, Chen-Khong Tham, "Transformer-based Reinforcement Learning for Base Station Selection", 2025](https://doi.org/10.1109/GLOBECOM59602.2025.11432277)
+* [Boikobo Nokane, Bassey Isong, Moshe T. Masonta, "Evaluating Reinforcement Learning-Based Xapps for User-Centric Resource Allocation in Open RAN", 2025](https://doi.org/10.1109/IMITEC67386.2025.11410449)
+* [Konrad Nowosadko, Franco Ruggeri, Ahmad Terra, "Self-Explaining Reinforcement Learning for Mobile Network Resource Allocation", 2025](https://arxiv.org/abs/2509.14925)
+* [Ziyang Zhang, Yiming Liu, Zheng Jiang, Bei Yang, Jianchi Zhu, "An Intelligent Energy-Efficient Handover Scheme Based on CoMP for Heterogeneous Network", 2024](https://doi.org/10.1109/LCOMM.2024.3375283)
+* [Harun Ur Rashid, Seong Ho Jeong, "Resource Allocation in Multi-Cell Networks: A Deep Reinforcement Learning Approach", 2023](https://doi.org/10.1109/ICTC58733.2023.10393199)
 * [Mohammadreza Kouchaki and Vuk Marojevic, "Actor-Critic Network for O-RAN Resource Allocation: xApp Design, Deployment, and Analysis", 2022](https://arxiv.org/abs/2210.04604)
 * [Stefan Schneider, Ramin Khalili, Artur Hecker, Holger Karl, "DeepCoMP: Self-Learning Dynamic Multi-Cell Selection for Coordinated Multipoint (CoMP)", 2021](https://github.com/CN-UPB/DeepCoMP)
 


### PR DESCRIPTION
## Summary

Google Scholar's full-text search for "mobile-env" surfaces several papers that Scholar isn't (yet) counting as citations in the profile for the NOMS 2022 paper, even though they clearly use this project. This adds those to the "Projects Using mobile-env" section.

For each candidate found via Scholar search, I checked the paper's own text/abstract (not just the search snippet) to confirm it actually uses `stefanbschneider/mobile-env` — as opposed to unrelated projects that happen to share the name (e.g. "Mobile-Env: Building qualified evaluation benchmarks for llm-gui interaction", an Android GUI-testing benchmark, which was excluded).

Confirmed and added (new to old):

- Islam, Barua, Ahmed, Begum — "Explaining Agents' Interactions Through their Causal Behavior and Counterfactuals", 2026 — explicitly names mobile-env as "a lightweight, Gym-compatible simulator" used for evaluation.
- Fang, Hong, Thieu, Choi, Lan — "ZODIAC: ...Multi-xApps Conflicts in Open Radio Access Networks", 2026 — evaluates on "the lightweight Mobile-Env platform", citing the NOMS 2022 paper directly.
- Helson, Alizadeh, Giovanidis — "Selecting Offline RL Algorithms for Stochastic Network Control", 2026 — evaluates offline RL methods "in an open-access stochastic telecom environment (mobile-env)".
- Huang, Tham — "Transformer-based Reinforcement Learning for Base Station Selection", GLOBECOM 2025 — evaluates using "mobile-env, the wireless simulation environment proposed by the DeepCoMP team".
- Nokane, Isong, Masonta — "Evaluating RL-Based Xapps for User-Centric Resource Allocation in Open RAN", 2025 — implements RL agents as xApps "in the mobile-env simulator".
- Nowosadko, Ruggeri, Terra — "Self-Explaining RL for Mobile Network Resource Allocation", 2025 — applies their method to "mobile-env, an environment that implements a resource allocation problem in mobile networks".
- Zhang, Liu, Jiang, Yang, Zhu — "An Intelligent Energy-Efficient Handover Scheme Based on CoMP for Heterogeneous Network", 2024 — builds their CoMP-based HetNet evaluation "using the mobile-env framework".
- Rashid, Jeong — "Resource Allocation in Multi-Cell Networks: A Deep Reinforcement Learning Approach", 2023 — trains a DQN on "a customized mobile-env simulation scenario".

Why Scholar likely isn't counting these yet in the profile: most are very recent (2025–2026, some still fresh preprints/in-press), and Scholar's citation-graph re-crawl of a specific profile's "cited by" counts lags its full-text search index by weeks to months. It's also possible some of these cite the GitHub repo/tool directly (a footnote/URL) rather than a formal bibliography entry pointing at the NOMS 2022 paper, which Scholar's citation parser wouldn't link to that paper's count either way — that would explain a permanent (not just delayed) gap for those particular papers.

## Changes

- `README.md`: 8 new entries added to "Projects Using mobile-env", ordered new to old by publication date, placed above the two existing entries (which remain the oldest).

No other files touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_019PtsVMQEwKX5uk4t3NV99z)_